### PR TITLE
fix: use correct resource name for domains example

### DIFF
--- a/docs/data-sources/domains.md
+++ b/docs/data-sources/domains.md
@@ -17,7 +17,7 @@ description: |-
 data "pihole_domains" "all" {}
 
 # Return all denied (blacklisted) domains registered with pihole
-data "pihole_domains" "allowed" {
+data "pihole_domains" "denied" {
   type = "deny"
 }
 ```

--- a/examples/data-sources/pihole_domains/data-source.tf
+++ b/examples/data-sources/pihole_domains/data-source.tf
@@ -2,6 +2,6 @@
 data "pihole_domains" "all" {}
 
 # Return all denied (blacklisted) domains registered with pihole
-data "pihole_domains" "allowed" {
+data "pihole_domains" "denied" {
   type = "deny"
 }


### PR DESCRIPTION
Wrong resource name slipped by in the list domains example