### PR TITLE
Update README re API token

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ Configure the provider with credentials, or pass environment variables.
 
 ```tf
 provider "pihole" {
-  url      = "https://pihole.domain.com" # PIHOLE_URL
-  password = var.pihole_password         # PIHOLE_PASSWORD
+  url       = "https://pihole.domain.com" # PIHOLE_URL
+  password  = var.pihole_password         # PIHOLE_PASSWORD
+
+  # api_token = var.pihole_api_token      # PIHOLE_API_TOKEN (experimental, requires Web Interface >= 5.11)
 }
 ```
 


### PR DESCRIPTION
Adds a comment about using API token instead of the admin password