### PR TITLE
Remove update DNS functions

### DIFF
--- a/docs/resources/dns_record.md
+++ b/docs/resources/dns_record.md
@@ -3,12 +3,12 @@
 page_title: "pihole_dns_record Resource - terraform-provider-pihole"
 subcategory: ""
 description: |-
-  
+  Manages a Pi-hole DNS record
 ---
 
 # pihole_dns_record (Resource)
 
-
+Manages a Pi-hole DNS record
 
 ## Example Usage
 
@@ -25,7 +25,7 @@ resource "pihole_dns_record" "record" {
 ### Required
 
 - **domain** (String) DNS record domain
-- **ip** (String) IP address where traffic is routed to from the DNS record domain
+- **ip** (String) IP address to route traffic to from the DNS record domain
 
 ### Optional
 

--- a/internal/pihole/cname.go
+++ b/internal/pihole/cname.go
@@ -156,30 +156,3 @@ func (c Client) DeleteCNAMERecord(ctx context.Context, domain string) error {
 
 	return nil
 }
-
-// UpdateCNAMERecord handles updates for CNAME records
-func (c Client) UpdateCNAMERecord(ctx context.Context, record *CNAMERecord) (*CNAMERecord, error) {
-	if c.tokenClient != nil {
-		return c.tokenClient.LocalCNAME.Update(ctx, record.Domain, record.Target)
-	}
-
-	current, err := c.GetCNAMERecord(ctx, record.Domain)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := c.DeleteCNAMERecord(ctx, record.Domain); err != nil {
-		return nil, err
-	}
-
-	updated, err := c.CreateCNAMERecord(ctx, record)
-	if err != nil {
-		_, recreateErr := c.CreateCNAMERecord(ctx, current)
-		if err != nil {
-			return nil, recreateErr
-		}
-		return nil, err
-	}
-
-	return updated, nil
-}

--- a/internal/pihole/dns.go
+++ b/internal/pihole/dns.go
@@ -127,33 +127,6 @@ func (c Client) GetDNSRecord(ctx context.Context, domain string) (*DNSRecord, er
 	return nil, NewNotFoundError(fmt.Sprintf("record %q not found", domain))
 }
 
-// UpdateDNSRecord deletes a pihole local DNS record by domain name
-func (c Client) UpdateDNSRecord(ctx context.Context, record *DNSRecord) (*DNSRecord, error) {
-	if c.tokenClient != nil {
-		return c.tokenClient.LocalDNS.Update(ctx, record.Domain, record.IP)
-	}
-
-	current, err := c.GetDNSRecord(ctx, record.Domain)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := c.DeleteDNSRecord(ctx, record.Domain); err != nil {
-		return nil, err
-	}
-
-	updated, err := c.CreateDNSRecord(ctx, record)
-	if err != nil {
-		_, recreateErr := c.CreateDNSRecord(ctx, current)
-		if err != nil {
-			return nil, recreateErr
-		}
-		return nil, err
-	}
-
-	return updated, nil
-}
-
 // DeleteDNSRecord deletes a pihole local DNS record by domain name
 func (c Client) DeleteDNSRecord(ctx context.Context, domain string) error {
 	if c.tokenClient != nil {

--- a/internal/provider/resource_cname_record.go
+++ b/internal/provider/resource_cname_record.go
@@ -14,7 +14,6 @@ func resourceCNAMERecord() *schema.Resource {
 		Description:   "Manages a Pi-hole CNAME record",
 		CreateContext: resourceCNAMERecordCreate,
 		ReadContext:   resourceCNAMERecordRead,
-		UpdateContext: resourceCNAMERecordUpdate,
 		DeleteContext: resourceCNAMERecordDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -30,6 +29,7 @@ func resourceCNAMERecord() *schema.Resource {
 				Description: "Value of the CNAME record where traffic will be directed to from the configured domain value",
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 			},
 		},
 	}
@@ -84,24 +84,6 @@ func resourceCNAMERecordRead(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	return diags
-}
-
-// resourceCNAMERecordUpdate handles CNAME record updates via Terraform
-func resourceCNAMERecordUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
-	client, ok := meta.(*pihole.Client)
-	if !ok {
-		return diag.Errorf("Could not load client in resource request")
-	}
-
-	_, err := client.UpdateCNAMERecord(ctx, &pihole.CNAMERecord{
-		Domain: d.Get("domain").(string),
-		Target: d.Get("target").(string),
-	})
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	return resourceCNAMERecordRead(ctx, d, meta)
 }
 
 // resourceCNAMERecordDelete handles the deletion of a CNAME record via Terraform

--- a/internal/provider/resource_dns_record.go
+++ b/internal/provider/resource_dns_record.go
@@ -11,9 +11,9 @@ import (
 // resourceDNSRecord returns the local DNS Terraform resource management configuration
 func resourceDNSRecord() *schema.Resource {
 	return &schema.Resource{
+		Description:   "Manages a Pi-hole DNS record",
 		CreateContext: resourceDNSRecordCreate,
 		ReadContext:   resourceDNSRecordRead,
-		UpdateContext: resourceDNSRecordUpdate,
 		DeleteContext: resourceDNSRecordDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -26,9 +26,10 @@ func resourceDNSRecord() *schema.Resource {
 				ForceNew:    true,
 			},
 			"ip": {
-				Description: "IP address where traffic is routed to from the DNS record domain",
+				Description: "IP address to route traffic to from the DNS record domain",
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 			},
 		},
 	}
@@ -83,24 +84,6 @@ func resourceDNSRecordRead(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	return diags
-}
-
-// resourceDNSRecordUpdate handles updates of a local DNS record via Terraform
-func resourceDNSRecordUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
-	client, ok := meta.(*pihole.Client)
-	if !ok {
-		return diag.Errorf("Could not load client in resource request")
-	}
-
-	_, err := client.UpdateDNSRecord(ctx, &pihole.DNSRecord{
-		Domain: d.Get("domain").(string),
-		IP:     d.Get("ip").(string),
-	})
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	return resourceDNSRecordRead(ctx, d, meta)
 }
 
 // resourceDNSRecordDelete handles the deletion of a local DNS record via Terraform


### PR DESCRIPTION
Removes the "update" functions for CNAME and A records. The Pi-hole API does not formally support updates, just list, create, delete. Update was implemented here by combining create and delete, which is not atomic but would be assumed to be so if you didn't inspect the code. Instead of creating/deleting under the hood which wasn't a great idea in the first place, we can have Terraform do this for us by forcing replacement on cname.target and dns.ip. This way the implications of the proposed changes are clearly stated by the Terraform plan, instead of hiding the behavior behind a function.