### PR TITLE
Bump go-pihole@0.0.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/PuerkitoBio/goquery v1.8.0
 	github.com/hashicorp/terraform-plugin-docs v0.5.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
-	github.com/ryanwholey/go-pihole v0.0.3
+	github.com/ryanwholey/go-pihole v0.0.4
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,8 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
-github.com/ryanwholey/go-pihole v0.0.3 h1:Z7qHaCdmlzbrvGtnCAj/Cn3tv/sXTcVwZHay3f8e9Po=
-github.com/ryanwholey/go-pihole v0.0.3/go.mod h1:phf6eVUv7QXC8OspfnIu6fGe+4jguTtPqyiMwh4AOBM=
+github.com/ryanwholey/go-pihole v0.0.4 h1:cEEzU52T73h6kzLfEfQNMVWUf46JAdLhrwuKvnZRdI4=
+github.com/ryanwholey/go-pihole v0.0.4/go.mod h1:phf6eVUv7QXC8OspfnIu6fGe+4jguTtPqyiMwh4AOBM=
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=


### PR DESCRIPTION
Bump go-pihole@[0.0.4](https://github.com/ryanwholey/go-pihole/releases/tag/v0.0.4) which removes some unused update methods and adds support for ad block enable/disable in the API token client