### PR TITLE
chore: Add release QOL updates

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -27,6 +27,7 @@ branches:
         contexts:
           - test
           - lint
+          - pr-lint
       enforce_admins: false    
       required_linear_history: true
       restrictions: null

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,17 @@
+name: Pull Request Lint
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: pr-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Unshallow
-        run: git fetch --prune --unshallow
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,8 +47,8 @@ signs:
       - "${signature}"
       - "--detach-sign"
       - "${artifact}"
-release:
+release: {}
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  skip: true
+  skip: false


### PR DESCRIPTION
- Enables the changelog for release notes, which is disabled in Hashicorp's [example](https://raw.githubusercontent.com/hashicorp/terraform-provider-scaffolding/main/.goreleaser.yml) 
- Adds a linter to assert PR titles are semantically prefixed
- Ensures pr-lint passes before merging