### PR TITLE
test: Use test matrix against different Pi-hole docker versions

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -25,7 +25,6 @@ branches:
       required_status_checks:
         strict: true
         contexts:
-          - test
           - lint
           - pr-lint
       enforce_admins: false    

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,13 @@ jobs:
     env:
       PIHOLE_URL: http://localhost:8080
       PIHOLE_PASSWORD: test
+    strategy:
+      matrix:
+        tag:
+          - "latest"
+          - "nightly"
+          - "2022.02.1"
+          - "2022.01.1"
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -35,8 +42,10 @@ jobs:
         with:
           terraform_wrapper: false
 
-      - name: Start pihole
-        run: docker-compose up -d
+      - name: Start Pi-hole
+        shell: bash
+        run: |-
+          docker-compose -f docker-compose.yml -f <(echo '{"services": {"pihole":{"image": "pihole/pihole:${{ matrix.tag }}"}}}') up -d --build
 
       - name: Run tests
         run: make testall


### PR DESCRIPTION
Adds different test image tags to ensure that the provider maintains a reasonable amount of compatibility. Also removes the "required" test check because we're testing against nightly, which should be unstable, but will be a good indicator of what's to come.