### PR TITLE
ci: Remove latest from test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,8 @@ jobs:
     strategy:
       matrix:
         tag:
-          - "latest"
+          - "2022.05"
+          - "2022.04.3"
           - "2022.02.1"
           - "2022.01.1"
     steps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
   pihole:
     container_name: pihole
-    image: pihole/pihole:latest
+    image: pihole/pihole:2022.05
     ports:
       - "8080:80/tcp"
     environment:


### PR DESCRIPTION
Removes "latest" from the normal testing matrix which should introduce some stability for contributors. Tags >= `2022.07.1` fail the tests, so I'll open a ticket to see what we can do there. Until those test failures are resolved, the provider will not officially  >= `2022.07.1`