### PR TITLE
chore: fix typo in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 ---
-versions: 2
+version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Would be nice for a dependabot config linter. Sorry about that typo.