### PR TITLE
feat: add parameter to use custom CA file

### DIFF
--- a/internal/provider/config.go
+++ b/internal/provider/config.go
@@ -2,6 +2,11 @@ package provider
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net/http"
 
 	"github.com/ryanwholey/terraform-provider-pihole/internal/pihole"
 )
@@ -19,15 +24,39 @@ type Config struct {
 
 	// Pi-hole API token
 	APIToken string
+
+	// Custom CA file
+	CAFile string
 }
 
 // Client initializes a new pihole client from the passed configuration
 func (c Config) Client(ctx context.Context) (*pihole.Client, error) {
+	HttpClient := &http.Client{}
+	if c.CAFile != "" {
+		certs, err := ioutil.ReadFile(c.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA file %q: %v", c.CAFile, err)
+		}
+
+		rootCAs := x509.NewCertPool()
+		rootCAs.AppendCertsFromPEM(certs)
+		tlsConfig := &tls.Config{
+			RootCAs: rootCAs,
+		}
+
+		HttpClient = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: tlsConfig,
+			},
+		}
+	}
+
 	config := pihole.Config{
 		URL:       c.URL,
 		Password:  c.Password,
 		UserAgent: c.UserAgent,
 		APIToken:  c.APIToken,
+		Client:    HttpClient,
 	}
 
 	client := pihole.New(config)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -31,6 +31,12 @@ func Provider() *schema.Provider {
 				Description:  "Experimental: Pi-hole API token. Conflicts with `password`.",
 				ExactlyOneOf: []string{"api_token", "password"},
 			},
+			"ca_file": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("PIHOLE_CA_FILE", nil),
+				Description: "CA file to connect to Pi-hole with TLS",
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -61,6 +67,7 @@ func configure(version string, provider *schema.Provider) func(ctx context.Conte
 			URL:       d.Get("url").(string),
 			UserAgent: provider.UserAgent("terraform-provider-pihole", version),
 			APIToken:  d.Get("api_token").(string),
+			CAFile:    d.Get("ca_file").(string),
 		}.Client(ctx)
 		if err != nil {
 			return nil, diag.FromErr(err)


### PR DESCRIPTION
I added the optional parameter `ca_file` to use custom CA certificate:
```
provider "pihole" {
  url = "https://pihole.your.home.local"
  api_token = var.pihole_api_token
  ca_file = "/path/to/your/ca.crt"
}
```