### PR TITLE
fix: Update lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,5 +24,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.45.2
+          version: v1.54
           args: --timeout 10m0s


### PR DESCRIPTION
Updates the go lint action because the current workflow is broken