### PR TITLE
fix: Ignore windows/arm64 build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,6 +28,8 @@ builds:
   ignore:
     - goos: darwin
       goarch: '386'
+    - goos: windows
+      goarch: arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip


### PR DESCRIPTION
Fixes an error which appeared after the recent release workflow update

```
  ⨯ release failed after 3m23s               error=failed to build for windows_arm64: exit status 2: cmd/go: unsupported GOOS/GOARCH pair windows/arm64

Error: The process '/opt/hostedtoolcache/goreleaser-action/1.22.1/x64/goreleaser' failed with exit code 1
```