### PR TITLE
feat: Add weekly job + fix broken test

### DIFF
--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -12,8 +12,8 @@ jobs:
         version: [
           "2022.07", # Current test version used.
           "2022.12.1", # Latest version of 2022.
-          "2023.11.0" # Latest version of 2023.
-          "2024.06.0" # Latest known version of 2024.
+          "2023.11.0", # Latest version of 2023.
+          "2024.06.0", # Latest known version of 2024.
         ]
 
     runs-on: ubuntu-latest

--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -9,9 +9,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-        env:
-          PIHOLE_URL: http://localhost:8080
-          PIHOLE_PASSWORD: test
+    env:
+      PIHOLE_URL: http://localhost:8080
+      PIHOLE_PASSWORD: test
 
     steps:
       - name: Checkout code

--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Start Pi-hole
         shell: bash
         run: |-
-          docker-compose -f docker-compose.yml -f <(echo '{"services": {"pihole":{"image": "pihole/pihole:2022.07"}}}') up -d --build
+          docker compose -f docker-compose.yml -f <(echo '{"services": {"pihole":{"image": "pihole/pihole:2022.07"}}}') up -d --build
 
       - name: Run tests
         run: make testall

--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -9,7 +9,12 @@ jobs:
   test:
     strategy:
       matrix:
-        version: ["2022.07", "2022.08"]
+        version: [
+          "2022.07", # Current test version used.
+          "2022.12.1", # Latest version of 2022.
+          "2023.11.0" # Latest version of 2023.
+          "2024.06.0" # Latest known version of 2024.
+        ]
 
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Start Pi-hole
         shell: bash
         run: |-
-          docker-compose -f docker-compose.yml -f <(echo '{"services": {"pihole":{"image": "pihole/pihole:2022.06"}}}') up -d --build
+          docker-compose -f docker-compose.yml -f <(echo '{"services": {"pihole":{"image": "pihole/pihole:2022.07"}}}') up -d --build
 
       - name: Run tests
         run: make testall

--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -1,0 +1,36 @@
+name: Weekly test job
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    #    env:
+    #      PIHOLE_URL: http://localhost:8080
+    #      PIHOLE_PASSWORD: test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.16
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_wrapper: false
+
+      - name: Start Pi-hole
+        shell: bash
+        run: |-
+          docker-compose -f docker-compose.yml -f <(echo '{"services": {"pihole":{"image": "pihole/pihole:latest"}}}') up -d --build
+
+      - name: Run tests
+        run: make testall

--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Start Pi-hole
         shell: bash
         run: |-
-          docker-compose -f docker-compose.yml -f <(echo '{"services": {"pihole":{"image": "pihole/pihole:2023.01"}}}') up -d --build
+          docker-compose -f docker-compose.yml -f <(echo '{"services": {"pihole":{"image": "pihole/pihole:2022.05"}}}') up -d --build
 
       - name: Run tests
         run: make testall

--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Start Pi-hole
         shell: bash
         run: |-
-          docker-compose -f docker-compose.yml -f <(echo '{"services": {"pihole":{"image": "pihole/pihole:2022.05"}}}') up -d --build
+          docker-compose -f docker-compose.yml -f <(echo '{"services": {"pihole":{"image": "pihole/pihole:2022.07"}}}') up -d --build
 
       - name: Run tests
         run: make testall

--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -14,6 +14,8 @@ jobs:
           "2022.12.1", # Latest version of 2022.
           "2023.11.0", # Latest version of 2023.
           "2024.06.0", # Latest known version of 2024.
+          "latest",
+          "nightly"
         ]
 
     runs-on: ubuntu-latest

--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Start Pi-hole
         shell: bash
         run: |-
-          docker-compose -f docker-compose.yml -f <(echo '{"services": {"pihole":{"image": "pihole/pihole:latest"}}}') up -d --build
+          docker-compose -f docker-compose.yml -f <(echo '{"services": {"pihole":{"image": "pihole/pihole:2023.05.1"}}}') up -d --build
 
       - name: Run tests
         run: make testall

--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -7,6 +7,10 @@ on:
 
 jobs:
   test:
+    strategy:
+      matrix:
+        version: ["2022.07", "2022.08"]
+
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -30,7 +34,7 @@ jobs:
       - name: Start Pi-hole
         shell: bash
         run: |-
-          docker compose -f docker-compose.yml -f <(echo '{"services": {"pihole":{"image": "pihole/pihole:2022.07"}}}') up -d --build
+          docker compose -f docker-compose.yml -f <(echo '{"services": {"pihole":{"image": "pihole/pihole:${{ matrix.version }}"}}}') up -d --build
 
       - name: Run tests
         run: make testall

--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -9,9 +9,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    #    env:
-    #      PIHOLE_URL: http://localhost:8080
-    #      PIHOLE_PASSWORD: test
+        env:
+          PIHOLE_URL: http://localhost:8080
+          PIHOLE_PASSWORD: test
 
     steps:
       - name: Checkout code

--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Start Pi-hole
         shell: bash
         run: |-
-          docker-compose -f docker-compose.yml -f <(echo '{"services": {"pihole":{"image": "pihole/pihole:2022.07"}}}') up -d --build
+          docker-compose -f docker-compose.yml -f <(echo '{"services": {"pihole":{"image": "pihole/pihole:2022.06"}}}') up -d --build
 
       - name: Run tests
         run: make testall

--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Start Pi-hole
         shell: bash
         run: |-
-          docker-compose -f docker-compose.yml -f <(echo '{"services": {"pihole":{"image": "pihole/pihole:2023.05.1"}}}') up -d --build
+          docker-compose -f docker-compose.yml -f <(echo '{"services": {"pihole":{"image": "pihole/pihole:2023.01"}}}') up -d --build
 
       - name: Run tests
         run: make testall

--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.16
+          go-version: 1.22
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2

--- a/.github/workflows/weekly-test.yml
+++ b/.github/workflows/weekly-test.yml
@@ -1,9 +1,8 @@
 name: Weekly test job
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
+  schedule:
+    - cron: '0 12 * * 1' # 12:00 every Monday.
 
 jobs:
   test:

--- a/internal/pihole/groups.go
+++ b/internal/pihole/groups.go
@@ -247,7 +247,7 @@ func (c Client) DeleteGroup(ctx context.Context, name string) error {
 
 	req, err := c.RequestWithSession(ctx, "POST", "/admin/scripts/pi-hole/php/groups.php", &url.Values{
 		"action": []string{"delete_group"},
-		"id":     []string{strconv.FormatInt(toDelete.ID, 10)},
+		"id":     []string{fmt.Sprintf("[%s]", strconv.FormatInt(toDelete.ID, 10))},
 	})
 	if err != nil {
 		return err

--- a/internal/provider/resource_group.go
+++ b/internal/provider/resource_group.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ryanwholey/terraform-provider-pihole/internal/pihole"
 )
 
-// resorceGroup returns the Terraform resource management configuration for a Pi-hole group
+// resourceGroup returns the Terraform resource management configuration for a Pi-hole group
 func resourceGroup() *schema.Resource {
 	return &schema.Resource{
 		Description:   "A construct to associate clients with allow/deny lists and/or adlists",

--- a/internal/provider/resource_group_test.go
+++ b/internal/provider/resource_group_test.go
@@ -44,7 +44,7 @@ func testGroupResourceConfig(resourceName, name, description string, enabled boo
 			name        = %q
 			description = %q
 			enabled     = %v
-		}	
+		}
 	`, resourceName, name, description, enabled)
 }
 
@@ -82,11 +82,14 @@ func testAccCheckGroupDestroy(s *terraform.State) error {
 			return fmt.Errorf("group name not found on primary resource")
 		}
 
-		if _, err := client.GetGroup(context.Background(), name); err != nil {
-			if _, ok := err.(*pihole.NotFoundError); !ok {
-				return err
-			}
+		_, err := client.GetGroup(context.Background(), name)
+		_, sameErr := err.(*pihole.NotFoundError)
+
+		if sameErr != true {
+			return err
 		}
+
+		continue
 	}
 
 	return nil


### PR DESCRIPTION
Hello! First off, thank you for creating this Terraform provider. I'm glad that it exists and hope that its features will grow in the future!

I saw that there was an issue regarding adding a weekly job, https://github.com/ryanwholey/terraform-provider-pihole/issues/43. I have added a matrix job that tests for various versions going from the version that is currently being tested up until latest and nightly builds.

When attempting to upgrade from docker tag 2022.05 to 2022.07, the tests started failing. Although I have very little experience doing feature work och troubleshooting terraform providers, I figured I could take a stab at it.

I could narrow down the issue to the `TestAccGroups`  test which, as of 2022.07, started throwing the issue `Invalid payload: id is not an array`. I narrowed it down even further and found that it fails when attempting to do a delete of the group, so I observed how the request in the ui looks compared to how to go code does it.

POST http://localhost:8080/admin/scripts/pi-hole/php/groups.php
Body:
```
action	"delete_group"
id	"[33]"
token	"REDACTED"
```

The id is wrapped in square brackets, while in the go code we form the request [such as](https://github.com/ryanwholey/terraform-provider-pihole/blob/main/internal/pihole/groups.go#L248-L251):
```go
req, err := c.RequestWithSession(ctx, "POST", "/admin/scripts/pi-hole/php/groups.php", &url.Values{
	"action": []string{"delete_group"},
	"id":     []string{strconv.FormatInt(toDelete.ID, 10)},
})
```
That's where it is now incompatible as of pihole 2022.07, when it introduced [this piece of validation](https://github.com/pi-hole/web/pull/2177/files#diff-8d18abbe77d19d00dbe4dbe76db69ec925fb010449a4b6d54c2e8dce9c0ddb0fR54-R58).

So I rewrote that logic a bit to wrap it into a set of square brackets which made the code happy again.

The test was still a bit grumpy tho, as the post destroy validation function was failing. It was due to this:

```go
if _, ok := err.(*pihole.NotFoundError); !ok {
	return err
}
```

I believe that the logic should say that if the error is the same as the NotFoundError error, then we can assume that the group has been properly deleted, and we should pass the check. So I flipped the logic to say this instead:

```go
_, err := client.GetGroup(context.Background(), name)
_, sameErr := err.(*pihole.NotFoundError)

if sameErr != true {
	return err
}	
```

Please let me know if I need to change anything.